### PR TITLE
Added to reward XP tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,11 @@
                             <span>TOTAL XP: {{encounterExp}} XP <b v-if="activeEncounterDifficulty.displayName != ''">(<i :class="'bi-reception-'+activeEncounterDifficulty.id+' encounter-'+activeEncounterDifficulty.displayName.toLowerCase()" class="bi"></i>{{activeEncounterDifficulty.displayName}})</b></span>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="col-auto">
+                            <span>TOTAL XP TO HANDOUT: {{encounterExpFourMan}} XP</span>
+                        </div>
+                    </div>
                     <div v-if="addedCreatures.length > 0" class="mt-2">
                         <button type="button" class="btn btn-primary mb-1" v-on:click="resetEncounter">Reset encounter</button>
                     </div>
@@ -455,6 +460,7 @@
                 partySize: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                 partyLevel: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
                 encounterExp: 0,
+                encounterExpFourMan: 0,
                 difficultyStyle: "font-weight: bold;",
                 encounters: [],
                 encounterCounter: 0,
@@ -737,6 +743,9 @@
                     this.addedCreatures.forEach(creature => {
                         this.adjustEncounterExpForCreatureLvl(getCreatureLevel(creature), creature.amount);
                     });
+
+                    //this.encounterExpFourMan = 4 / this.partyFilters.partySizeFilter * this.encounterExp; 
+                    this.encounterExpFourMan = (4 / this.partyFilters.partySizeFilter) * this.encounterExp; 
                 },
                 saveCreatures: function(){
                     window.localStorage.addedCreatures = JSON.stringify(this.addedCreatures);


### PR DESCRIPTION
Added a to reward XP tracker to the fight club.

With this a GM can easily see the XP they should reward if their party is a smaller or greater than a four man party. For example a Moderate Encounter should always provide 80XP, even if the party is of a size larger or smaller than four. See Core Rulebook page 508 Party Size for more information.

![image](https://user-images.githubusercontent.com/9928487/111219338-2ed3e180-85d8-11eb-9e1f-7f5f11c44265.png)
