### PR TITLE
Revert xp to four player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+scrapperStats/*

--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
                     </div>
                     <div class="row">
                         <div class="col-auto">
-                            <span>AWARDED XP PER PLAYER: {{encounterExp}} XP</span>
+                            <span>AWARDED XP PER PLAYER: {{encounterExpFourMan}} XP</span>
                         </div>
                     </div>
                     <div class="table-responsive">
@@ -569,6 +569,7 @@
                 partySize: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                 partyLevel: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
                 encounterExp: 0,
+                encounterExpFourMan: 0,
                 difficultyStyle: "font-weight: bold;",
                 encounters: [],
                 encounterCounter: 0,
@@ -1047,6 +1048,7 @@
                     this.addedCreatures.forEach(creature => {
                         this.adjustEncounterExpForCreatureLvl(getCreatureLevel(creature), creature.amount);
                     }); 
+                    this.encounterExpFourMan = Math.floor((4 / this.partyFilters.partySizeFilter) * this.encounterExp);
                 },
                 saveCreatures: function(){
                     window.localStorage.addedCreatures = JSON.stringify(this.addedCreatures);


### PR DESCRIPTION
Reverts the recent xp change from #64.
After closer analysis of the rules, the awarded XP should alway be what you award to a group of four players.

Relevant rules: https://2e.aonprd.com/Rules.aspx?ID=578
> The rules for encounters (page 489) describe how to accommodate groups of a different size, but the XP awards don’t change—always award the amount of XP listed for a group of four characters.

While you adjust the XP budget by 1/4 per players added or removed you should alway award the XP for a group of 4 ignoring adjustments to party size.
A group of 2 player loses half the XP budget and should therefore received 2x the adjusted xp budget
A group of 6 player increases the budget by half bringing it to 150%, to bring it back to a 4 player party we must award 2/3 of the xp budget

We must always award `adjustedbudget * 4/number of players`