### PR TITLE
Add Sources as a Filter and Viewable column on the Creature table

### DIFF
--- a/components/creatureListItem.js
+++ b/components/creatureListItem.js
@@ -37,6 +37,12 @@ Vue.component('creature-list-item', {
                 <span v-if="index < creature.traits.length -1"></span>
             </span>
         </td>
+        <td>
+            <a v-if="creature.source.link !== ''" :href="creature.source.link" @click.prevent.exact="$emit('open-link', creature.source.link)" v-on:click.ctrl.exact="$emit('add-filter', [creature.source.name, 'source'])">{{ creature.source.name }}</a>
+            <template v-else>
+                {{creature.source.name}}
+            </template>
+        </td>
     </tr>
     `
 });

--- a/index.html
+++ b/index.html
@@ -487,6 +487,11 @@
                                                 <option v-for="trait in traits" :value="trait.value">{{trait.displayName}}</option>
                                             </select>
                                         </td>
+                                        <td>
+                                            <select v-model='creature.source' class="form-select">
+                                                <option v-for="source in sources" :value="source.value">{{source.displayName}}</option>
+                                            </select>
+                                        </td>
                                     </tr>
                                     <template v-for="creature in filteredCreatureList">
                                         <creature-list-item :creature="creature"

--- a/index.html
+++ b/index.html
@@ -995,7 +995,8 @@
                         "alignment": this.filters.alignmentFilter, 
                         "type": this.filters.typeFilter, 
                         "size": this.filters.sizeFilter,
-                        "traits": this.filters.traitFilter
+                        "traits": this.filters.traitFilter,
+                        "sources": this.filters.sourceFilter,
                     });
                 },
                 openLinkInPopup(link, event){

--- a/index.html
+++ b/index.html
@@ -769,6 +769,7 @@
                 'filters.alignmentFilter': function(){ this.automaticCreatureFilter(); },
                 'filters.sizeFilter': function(){ this.automaticCreatureFilter(); },
                 'filters.traitFilter': function(){ this.automaticCreatureFilter(); },
+                'filters.sourceFilter': function(){ this.automaticCreatureFilter(); },
                 encounters: {
                     handler: function(newEncounters, oldEncounters){
                         window.localStorage.encounters = JSON.stringify(this.encounters);
@@ -817,6 +818,7 @@
                         case 'alignment': filters = this.alignments; break;
                         case 'level': this.updateLevelFilter(filterName); return;
                         case 'size': filters = this.sizes; break;
+                        case 'source': filters = this.sources; break;
                     }      
                     var foundFilter = filters.find((filter) => {
                         return filter.displayName == filterName;
@@ -953,6 +955,9 @@
                             isInTheList = false;
                         };
                         if (this.traitFilter.length > 0 && !this.traitFilter.find((el) => { return creature.traits.find(trait => trait.name.toLowerCase() === el); })) {
+                            isInTheList = false;
+                        };
+                        if (this.sourceFilter.length > 0 && !this.sourceFilter.find((el) => { return el === creature.source.name.toLowerCase(); })) {
                             isInTheList = false;
                         };
                        return isInTheList;

--- a/index.html
+++ b/index.html
@@ -606,6 +606,11 @@
                         .filter((el) => { return el.selected === true })
                         .map((el) => { return el.value });
                 },
+                sourceFilter: function () {
+                    return this.sources
+                        .filter((el) => { return el.selected === true })
+                        .map((el) => { return el.value });
+                },
                 encounterCreatures: function(){
                     return this.addedCreatures;
                 },

--- a/index.html
+++ b/index.html
@@ -565,6 +565,7 @@
                 sizes: [],
                 traits: [],
                 levels: [],
+                sources: [],
                 addedCreatures: [],
                 partySize: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                 partyLevel: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
@@ -675,6 +676,14 @@
                 });
                 this.traits.sort(sortString);
                 
+                this.creatureList.forEach((creature) => {
+                    let source = creature.source.name;
+                    if(!this.sources.find(lowerCaseMatch(source, "value"))){                        
+                        this.sources.push({displayName:source, value:source.toLowerCase(), selected: false});
+                    }
+                });
+                this.sources.sort(sortString);
+
                 this.creatureList.forEach((creature) => {
                     if(!this.levels.includes(creature.level)){                        
                         this.levels.push(creature.level);

--- a/index.html
+++ b/index.html
@@ -487,11 +487,7 @@
                                                 <option v-for="trait in traits" :value="trait.value">{{trait.displayName}}</option>
                                             </select>
                                         </td>
-                                        <td>
-                                            <select v-model='creature.source' class="form-select">
-                                                <option v-for="source in sources" :value="source.value">{{source.displayName}}</option>
-                                            </select>
-                                        </td>
+                                        <td><input type="text" v-model="creature.source" class="form-control"></td>
                                     </tr>
                                     <template v-for="creature in filteredCreatureList">
                                         <creature-list-item :creature="creature"
@@ -1024,6 +1020,7 @@
                     this.types.map((el) => el.selected = false);
                     this.sizes.map((el) => el.selected = false);
                     this.traits.map((el) => el.selected = false);
+                    this.sources.map((el) => el.selected = false);
                     
                     this.setMinLevelFilter();
                     this.setMaxLevelFilter();                    

--- a/index.html
+++ b/index.html
@@ -413,7 +413,12 @@
                             <label for="traitFilter" class="form-label">Traits</label>
                             <multi-select :options="traits" @selected="multiSelectToggle(traits, $event)"
                                 @closed="closeFilterMultiSelect(traits)" name="traitFilter"></multi-select>
-                        </div>                    
+                        </div>
+                        <div class="order-2 col-4 col-sm">
+                            <label for="sourceFilter" class="form-label">Sources</label>
+                            <multi-select :options="sources" @selected="multiSelectToggle(sources, $event)"
+                                @closed="closeFilterMultiSelect(sources)" name="sourceFilter"></multi-select>
+                        </div>                         
                         <div class="order-1 order-sm-2 col-4 col-sm align-self-end">
                             <button type="button" class="btn btn-primary w-100" v-on:click="resetFilters">Reset filters</button>
                         </div>   
@@ -434,6 +439,7 @@
                                         <th scope="col">Types</th>
                                         <th scope="col">Size</th>
                                         <th scope="col">Traits</th>
+                                        <th scope="col">Source</th>
                                     </tr>
                                 </thead>
                                 <tbody>


### PR DESCRIPTION
Resolves #68

Added functionality to display Sources as a Filterable parameter, and display relevant sources to a creature on the table by replicating existing work.

~~Current issue: need to figure out how to not allow Source as a select field for Custom Creatures, but perhaps allow a text field.~~
Fixed in 31abeb2